### PR TITLE
Add assertions to JavaFx components

### DIFF
--- a/src/main/java/ipman/ui/javafx/MainWindow.java
+++ b/src/main/java/ipman/ui/javafx/MainWindow.java
@@ -39,6 +39,8 @@ public class MainWindow extends AnchorPane implements Initializable {
                 List<MessageBox> messageBoxes = c.getAddedSubList().stream()
                         .map(MessageBox::createMessage)
                         .toList();
+
+                assert !messageBoxes.isEmpty();
                 dialogContainer.getChildren().addAll(messageBoxes);
             }
         });
@@ -48,6 +50,9 @@ public class MainWindow extends AnchorPane implements Initializable {
 
     @FXML
     private void handleOnSendClick() {
+        assert this.inputTextField != null;
+        assert this.viewModel != null;
+
         // Read message and clear input
         String message = this.inputTextField.getText();
         this.inputTextField.setText("");

--- a/src/main/java/ipman/ui/javafx/MainWindowViewModel.java
+++ b/src/main/java/ipman/ui/javafx/MainWindowViewModel.java
@@ -41,6 +41,7 @@ public class MainWindowViewModel {
     }
 
     private void addMessage(String message) {
+        assert !message.isBlank();
         this.messages.add(new Message(MessageAuthor.SYSTEM, message));
     }
 

--- a/src/main/java/ipman/ui/javafx/components/MessageBox.java
+++ b/src/main/java/ipman/ui/javafx/components/MessageBox.java
@@ -1,6 +1,7 @@
 package ipman.ui.javafx.components;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import ipman.ui.javafx.Message;
 import javafx.fxml.FXML;
@@ -34,6 +35,12 @@ public class MessageBox extends GridPane {
         this.displayPicture.setImage(img);
     }
 
+    private static Image loadImage(String resourcePath) {
+        InputStream is = MessageBox.class.getResourceAsStream(resourcePath);
+        assert is != null;
+        return new Image(is);
+    }
+
     /**
      * Constructs a MessageBox for a user or system depending on the message's author
      *
@@ -54,7 +61,7 @@ public class MessageBox extends GridPane {
      * @return message box for the user
      */
     public static MessageBox createUserBox(String message) {
-        Image image = new Image(MessageBox.class.getResourceAsStream("/images/messageUserAvatar.png"));
+        Image image = loadImage("/images/messageUserAvatar.png");
         MessageBox box = new MessageBox(message, image);
         box.message.setAlignment(Pos.CENTER_RIGHT);
         return box;
@@ -67,7 +74,7 @@ public class MessageBox extends GridPane {
      * @return message box for the system
      */
     public static MessageBox createSystemBox(String message) {
-        Image image = new Image(MessageBox.class.getResourceAsStream("/images/messageSystemAvatar.png"));
+        Image image = loadImage("/images/messageSystemAvatar.png");
         MessageBox box = new MessageBox(message, image);
         GridPane.setColumnIndex(box.message, 1);
         GridPane.setColumnIndex(box.displayPicture, 0);


### PR DESCRIPTION
JavaFx relies heavily on the existence of resource files or IDs of particular nodes to exist in the FXML. When these are missing, this is most certainly a programming error. Therefore, add assertions to ensure they are properly loaded.